### PR TITLE
[ BUD-15339 ]: Potential fix for code scanning alert no. 3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/cases/migration_test.rb
+++ b/test/cases/migration_test.rb
@@ -665,7 +665,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert_equal [@migrations_path + "/4_people_have_hobbies.bukkits.rb", @migrations_path + "/5_people_have_descriptions.bukkits.rb"], copied.map(&:filename)
 
     expected = "# This migration comes from bukkits (originally 1)"
-    assert_equal expected, IO.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")[0].chomp
+    assert_equal expected, File.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")[0].chomp
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy"})


### PR DESCRIPTION
Potential fix for [https://github.com/OpenGov/activerecord5-redshift-adapter/security/code-scanning/3](https://github.com/OpenGov/activerecord5-redshift-adapter/security/code-scanning/3)

In general, to fix this class of issue you should avoid `Kernel.open` and `IO.*` file-reading helpers when given non-constant or externally influenced paths, and instead use the equivalent methods on `File` (`File.open`, `File.read`, `File.readlines`, etc.), which do not interpret a leading `|` as a shell command.

For this specific case, the safest and simplest fix is to replace `IO.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")` with `File.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")`. `File.readlines` has the same return type and behavior (an array of lines), so the subsequent indexing `[0].chomp` continues to work identically, and no other parts of the test need to change. No new helpers or imports are required; `File` is part of Ruby’s core library.

The only code change is within `test/cases/migration_test.rb` in the `CopyMigrationsTest#test_copying_migrations_without_timestamps` method at line 668: swap the class on the call from `IO` to `File`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
