### PR TITLE
[ BUD-15339 ]: Potential fix for code scanning alert no. 4: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/cases/migration_test.rb
+++ b/test/cases/migration_test.rb
@@ -769,7 +769,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert_equal [@migrations_path + "/4_currencies_have_symbols.bukkits.rb"], copied.map(&:filename)
 
     expected = "# coding: ISO-8859-15\n# This migration comes from bukkits (originally 1)"
-    assert_equal expected, IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp
+    assert_equal expected, File.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/magic"})


### PR DESCRIPTION
Potential fix for [https://github.com/OpenGov/activerecord5-redshift-adapter/security/code-scanning/4](https://github.com/OpenGov/activerecord5-redshift-adapter/security/code-scanning/4)

In general, this issue is fixed by avoiding `IO`-level helpers (`IO.read`, `IO.readlines`, etc.) and `Kernel.open` when given non-constant or non-validated paths, and instead using the corresponding `File` helpers (`File.read`, `File.readlines`, etc.), which do not interpret a leading `|` as a shell command.

For this specific case in `test/cases/migration_test.rb`, the best fix is to change the single usage of `IO.readlines` on line 772 to `File.readlines`, keeping the rest of the expression identical. `File.readlines` returns the same array of lines for a normal file, so the test behavior is unchanged. No additional imports or helper methods are required, and no other lines in this file need to be altered.

Concretely:
- In `test_copying_migrations_preserving_magic_comments`, locate line 772:
  - Replace `IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp`
  - With `File.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
